### PR TITLE
Add support for ISO 8601 date format

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Imports:
     jsonlite,
     data.table,
     rlang,
+    lubridate,
     utils,
     stringr,
     SummarizedExperiment,

--- a/R/processors.R
+++ b/R/processors.R
@@ -178,7 +178,9 @@ processDatasets <- function(d) {
         ee.Database = d[["externalDatabase"]],
         ee.URL = d[["externalUri"]],
         ee.Samples = d[["bioAssayCount"]],
-        ee.LastUpdated = as.POSIXct(d[["lastUpdated"]] / 1e3, origin = "1970-01-01"),
+        ee.LastUpdated = switch(is.character(d[["lastUpdated"]]),
+                                ymd_hms(d[["lastUpdated"]]), # parse ISO 8601 format
+                                as.POSIXct(d[["lastUpdated"]] / 1e3, origin = "1970-01-01")),
         ee.batchEffect = d[["batchEffect"]],
         geeq.batchCorrected = d[["geeq"]][["batchCorrected"]],
         geeq.qScore = d[["geeq"]][["publicQualityScore"]],


### PR DESCRIPTION
This is related to #18 

So, ISO 8601 is not part of base R and attempting to parse it using `strptime` will not deal properly with the timezone. Ugh.

I learned that `is.integer` does not return `TRUE` if provided with an integer.

I think this would be missing a `library(lubridate)` call somewhere to import the relevant functions.

Also, lubridate is part of Tidyverse. Is it something that is desirable?

Alternatives I considered:

 - [strptime](https://rdrr.io/r/base/strptime.html) from base R, but does not deal nicely with TZ
 - [parsedate](https://rdrr.io/cran/parsedate/)
 - [parse_datetime](https://readr.tidyverse.org/reference/parse_datetime.html) from readr, though that is a big dependency